### PR TITLE
To fix hook

### DIFF
--- a/inc/plugin.class.php
+++ b/inc/plugin.class.php
@@ -359,7 +359,7 @@ class Slack_Plugin {
     {
     	$hooks = $this->get_options();
 
-    	if(is_array($hooks)) :
+    	if(is_object($hooks)) :
     	if($hooks->slack_publish_post)
     	{
     		add_action('publish_post', array($this, 'publish_post_hook'));


### PR DESCRIPTION
get_options return value is object, not array.

cause : hook don't work.
